### PR TITLE
pollingを１秒に変更

### DIFF
--- a/app/entry.js
+++ b/app/entry.js
@@ -21,4 +21,4 @@ setInterval(() => {
   $.get('/server-status', {}, (data) => {
     loadavg.text(data.loadavg.toString());
   });
-}, 10);
+}, 1000);


### PR DESCRIPTION
練習用なので マージ不要です。
１秒に変更したのにロードアベレージの値が10ミリ秒のときとほとんど変わらないのは、
自分のマシン（あるいは通信環境）のせいでしょうか？