### PR TITLE
ポーリングの実行間隔を1秒に調整

### DIFF
--- a/app/entry.js
+++ b/app/entry.js
@@ -21,4 +21,4 @@ setInterval(() => {
   $.get('/server-status', {}, (data) => {
     loadavg.text(data.loadavg.toString());
   });
-}, 10);
+}, 1000);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "open": "PORT=8000 npm start"
   },
   "dependencies": {
     "body-parser": "~1.13.2",


### PR DESCRIPTION
練習なのでマージ不要です。

package.jsonの追記「"scripts": { "open": "PORT=8000 npm start" }」は
個人的に「PORT=」と打つのが面倒だったので、こうすることにより
「$ npm run open」というコマンドで楽に開けるようにしただけです。