### PR TITLE
サーバーステータス取得AJAXの実行間隔を10ミリ秒から1秒に変更

### DIFF
--- a/app/entry.js
+++ b/app/entry.js
@@ -21,4 +21,4 @@ setInterval(() => {
   $.get('/server-status', {}, (data) => {
     loadavg.text(data.loadavg.toString());
   });
-}, 10);
+}, 1000);


### PR DESCRIPTION
練習のためマージ不要